### PR TITLE
Typed quantifiers: `forall` and `exists`

### DIFF
--- a/Sources/Diagnostic/DiagnosticPool.swift
+++ b/Sources/Diagnostic/DiagnosticPool.swift
@@ -25,7 +25,7 @@ public class DiagnosticPool {
   }
 
   public func getDiagnostics() -> [Diagnostic] {
-       return diagnostics
+    return diagnostics
   }
 
   public func append(_ diagnostic: Diagnostic) {
@@ -33,7 +33,7 @@ public class DiagnosticPool {
   }
 
   public func appendAll(_ additions: [Diagnostic]) {
-        diagnostics.append(contentsOf: additions)
+    diagnostics.append(contentsOf: additions)
   }
 
   public func empty() {

--- a/Sources/Verifier/Boogie/BoogieAST.swift
+++ b/Sources/Verifier/Boogie/BoogieAST.swift
@@ -506,10 +506,6 @@ indirect enum BType: CustomStringConvertible, Hashable {
     }
   }
 
-  /* var hashValue: Int {
-    return self.description.hashValue
-  } */
-
   func hash(into hasher: inout Hasher) {
     hasher.combine(self.description)
   }

--- a/Sources/Verifier/Boogie/Function.swift
+++ b/Sources/Verifier/Boogie/Function.swift
@@ -267,7 +267,6 @@ extension BoogieTranslator {
       assert(argumentsExpressions.count == 3)
       let variableArgument: FunctionArgument = functionCall.arguments[0]
       let typeArgument: FunctionArgument = functionCall.arguments[0]
-      print(variableArgument.expression, typeArgument.expression)
 
       guard case .identifier(let variable) = variableArgument.expression,
             case .identifier(let type) = typeArgument.expression else {
@@ -291,7 +290,6 @@ extension BoogieTranslator {
       assert(argumentsExpressions.count == 3)
       let variableArgument: FunctionArgument = functionCall.arguments[0]
       let typeArgument: FunctionArgument = functionCall.arguments[0]
-      print(variableArgument.expression, typeArgument.expression)
 
       guard case .identifier(let variable) = variableArgument.expression,
             case .identifier(let type) = typeArgument.expression else {

--- a/Sources/Verifier/Boogie/Function.swift
+++ b/Sources/Verifier/Boogie/Function.swift
@@ -263,12 +263,35 @@ extension BoogieTranslator {
                                    propertyExpression)),
           argumentsStatements + triggerPreStmts,
           argumentPostStmts + triggerPostStmts)
+    case "forall":
+      assert(argumentsExpressions.count == 3)
+      let variableArgument: FunctionArgument = functionCall.arguments[0]
+      let typeArgument: FunctionArgument = functionCall.arguments[0]
+      print(variableArgument.expression, typeArgument.expression)
 
+      guard case .identifier(let variable) = variableArgument.expression,
+            case .identifier(let type) = typeArgument.expression else {
+        print("forall must be introduced with a typed variable declaration, for some t of type T: `t, T`")
+        fatalError()
+      }
+      self.currentFunctionReturningValue = variable.name
+      self.currentFunctionReturningValueValue = currentFunctionReturningValue.map { name in
+        return .identifier(name)
+      }
+      let (propertyExpression, _, _) = process(functionCall.arguments[2].expression,
+                                               shadowVariablePrefix: normaliser.getShadowArraySizePrefix)
+
+      let btype = convertType(
+           AST.Type(identifier: AST.Identifier(name: type.name, sourceLocation: typeArgument.sourceLocation)))
+
+      return (.quantified(.forall,
+                          [BParameterDeclaration(name: variable.name, rawName: variable.name, type: btype)],
+                          propertyExpression), [], [])
     default: break
     }
 
     guard let currentFunctionName = getCurrentFunctionName() else {
-      print("Unableto get current function name - while processing function call")
+      print("Unable to get current function name - while processing function call")
       fatalError()
     }
 

--- a/Sources/Verifier/Boogie/Function.swift
+++ b/Sources/Verifier/Boogie/Function.swift
@@ -287,6 +287,30 @@ extension BoogieTranslator {
       return (.quantified(.forall,
                           [BParameterDeclaration(name: variable.name, rawName: variable.name, type: btype)],
                           propertyExpression), [], [])
+    case "exists":
+      assert(argumentsExpressions.count == 3)
+      let variableArgument: FunctionArgument = functionCall.arguments[0]
+      let typeArgument: FunctionArgument = functionCall.arguments[0]
+      print(variableArgument.expression, typeArgument.expression)
+
+      guard case .identifier(let variable) = variableArgument.expression,
+            case .identifier(let type) = typeArgument.expression else {
+        print("exists must be introduced with a typed variable declaration, for some t of type T: `t, T`")
+        fatalError()
+      }
+      self.currentFunctionReturningValue = variable.name
+      self.currentFunctionReturningValueValue = currentFunctionReturningValue.map { name in
+        return .identifier(name)
+      }
+      let (propertyExpression, _, _) = process(functionCall.arguments[2].expression,
+                                               shadowVariablePrefix: normaliser.getShadowArraySizePrefix)
+
+      let btype = convertType(
+          AST.Type(identifier: AST.Identifier(name: type.name, sourceLocation: typeArgument.sourceLocation)))
+
+      return (.quantified(.exists,
+                          [BParameterDeclaration(name: variable.name, rawName: variable.name, type: btype)],
+                          propertyExpression), [], [])
     default: break
     }
 

--- a/Sources/Verifier/Boogie/Statement+Expression.swift
+++ b/Sources/Verifier/Boogie/Statement+Expression.swift
@@ -969,7 +969,7 @@ extension BoogieTranslator {
                                           subscriptDepth: Int = 0,
                                           localContext: Bool = true,
                                           isBeingAssignedTo: Bool = false
-  ) -> (BExpression, [BStatement], [BStatement]) {
+                                          ) -> (BExpression, [BStatement], [BStatement]) {
     var postAmble = [BStatement]()
     let (subExpr, subStmts, subPostStmts) = process(subscriptExpression.baseExpression,
                                                     localContext: localContext,


### PR DESCRIPTION
This fixes [flintlang/flint/#437](https://github.com/flintlang/flint/issues/437) by introducing new `forall` and `exists` quantifier functions to the verification system. Mirroring `arrayEach` they use function call syntax so as to not introduce any parsing issues.

```swift
assert (arrayEach (x, xs, x > 0) )
assert (forall (i, Int, i > 0 && i < xs.length ==> xs[i] > 0) )
assert (!exists (i, Int, i > 0 && i < xs.length && (xs[i] < 0 || xs[i] == 0)) )
``` 